### PR TITLE
Reworked grid()

### DIFF
--- a/source/game_expr.cpp
+++ b/source/game_expr.cpp
@@ -53,7 +53,7 @@ namespace xge
 		for (auto& rawObject : rawObjects)
 		{
 			std::vector<std::string> tempSpriteParams = processData(rawObject, rawObject.src);
-			GridData gridData = setGridData(tempSpriteParams);
+			GridData gridData = setGridXY(tempSpriteParams);
 
 			for (auto gridX = 0; gridX < gridData.max.x; gridX++)
 			{
@@ -67,13 +67,15 @@ namespace xge
 					object.src = rawObject.src;
 					object.isVisible = rawObject.isVisible;
 
-					object.position.x = evaluateString(rawObject, rawObject.rawPosition.x) + ((gridData.obj.x + gridData.padding.x) * gridX);
-					object.position.y = evaluateString(rawObject, rawObject.rawPosition.y) + ((gridData.obj.y + gridData.padding.y) * gridY);
+					object.position.x = static_cast<float>(gridX);
+					object.position.y = static_cast<float>(gridY);
 
 					object.velocity.x = evaluateString(rawObject, rawObject.rawVelocity.x);
 					object.velocity.y = evaluateString(rawObject, rawObject.rawVelocity.y);
 
-					object.positionOriginal = object.position;
+					object.positionOriginal.x = evaluateString(rawObject, rawObject.rawPosition.x);
+					object.positionOriginal.y = evaluateString(rawObject, rawObject.rawPosition.y);
+
 					object.velocityOriginal = object.velocity;
 
 					object.collisionData.enabled = rawObject.rawCollisionData.enabled;
@@ -115,28 +117,14 @@ namespace xge
 		return tempSParams;
 	}
 
-	xge::GridData game_expr::setGridData(std::vector<std::string>& tempSpriteParams)
+	xge::GridData game_expr::setGridXY(std::vector<std::string>& spriteParams)
 	{
 		GridData gridData;
 
-		if (tempSpriteParams.size() > 5)
+		if (spriteParams.size() > 5)
 		{
-			gridData.max.x = std::stoi(tempSpriteParams.at(5));
-			gridData.max.y = std::stoi(tempSpriteParams.at(6));
-
-			gridData.padding.x = std::stoi(tempSpriteParams.at(7));
-			gridData.padding.y = std::stoi(tempSpriteParams.at(8));
-
-			if (tempSpriteParams.at(4) == "grid" && tempSpriteParams.at(0) == "circle")
-			{
-				gridData.obj.x = std::stoi(tempSpriteParams.at(1)) * 2;
-				gridData.obj.y = std::stoi(tempSpriteParams.at(1)) * 2;
-			}
-			else if (tempSpriteParams.at(4) == "grid" && tempSpriteParams.at(0) == "rectangle")
-			{
-				gridData.obj.x = std::stoi(tempSpriteParams.at(1));
-				gridData.obj.y = std::stoi(tempSpriteParams.at(2));
-			}
+			gridData.max.x = std::stoi(spriteParams.at(5));
+			gridData.max.y = std::stoi(spriteParams.at(6));
 		}
 
 		return gridData;

--- a/source/game_sfml.cpp
+++ b/source/game_sfml.cpp
@@ -30,6 +30,10 @@ namespace xge
 				createImage(object);
 			}
 
+			GridData gridData = setGridData(object);
+			object.position.x = object.positionOriginal.x + ((gridData.obj.x + gridData.padding.x) * object.position.x);
+			object.position.y = object.positionOriginal.y + ((gridData.obj.y + gridData.padding.y) * object.position.y);
+
 			object.renderTexture->display();
 
 			object.sprite = std::make_unique<sf::Sprite>();
@@ -159,5 +163,25 @@ namespace xge
 
 		object.renderTexture->create(width, height);
 		object.renderTexture->draw(sprite);
+	}
+
+	xge::GridData game_sfml::setGridData(Object& object)
+	{
+		GridData gridData;
+		auto spriteParams = object.spriteParams;
+
+		if (spriteParams.size() > 5)
+		{
+			gridData.max.x = std::stoi(spriteParams.at(5));
+			gridData.max.y = std::stoi(spriteParams.at(6));
+
+			gridData.padding.x = std::stoi(spriteParams.at(7));
+			gridData.padding.y = std::stoi(spriteParams.at(8));
+
+			gridData.obj.x = object.renderTexture->getSize().x;
+			gridData.obj.y = object.renderTexture->getSize().y;
+		}
+
+		return gridData;
 	}
 }

--- a/source/include/game_expr.h
+++ b/source/include/game_expr.h
@@ -27,7 +27,7 @@ namespace xge
 
 		float evaluateString(const RawObject& rawObject, const std::string& input_string);
 		std::vector<std::string> processData(const RawObject& rawObject, const std::string& input_string);
-		xge::GridData setGridData(std::vector<std::string>& tempSpriteParams);
+		xge::GridData setGridXY(std::vector<std::string>& tempSpriteParams);
 	};
 
 	namespace

--- a/source/include/game_sfml.h
+++ b/source/include/game_sfml.h
@@ -30,5 +30,7 @@ namespace xge
 		void createRectangle(Object& object);
 		void createText(Object& object);
 		void createImage(Object& object);
+
+		GridData setGridData(Object& object);
 	};
 }

--- a/source/include/object.h
+++ b/source/include/object.h
@@ -62,8 +62,8 @@ namespace xge
 	struct GridData
 	{
 		Vector2i max{ 1,1 };
-		Vector2i padding;
-		Vector2i obj;
+		Vector2i padding{ 0,0 };
+		Vector2i obj{ 0,0 };
 	};
 
 	struct RawObject


### PR DESCRIPTION
game_expr::init() now stores grid x,y in object.position.x/y, and stores XML provided position in object.positionOriginal, game_sfml later uses the object's grid x,y positions and positionOrginal to calculate it's final real position